### PR TITLE
解决排行榜属于UGC个人主体小程序不能过审的问题

### DIFF
--- a/pages/index/feature.js
+++ b/pages/index/feature.js
@@ -248,6 +248,8 @@ Page({
     if (envVersion != 'release') {
       iconList[17].student = false
       iconList[17].teacher = false
+      iconList[16].student = false
+      iconList[16].teacher = false
     }
     
     try {


### PR DESCRIPTION
排行榜属于UGC个人主体小程序不能过审