### PR TITLE
v3.3.6 取消使用七牛云CDN&更新考证助手

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ App({
     domain: 'https://shellbox.airmole.cn/api',
     _amap_key: '66a87160f8db2a9a76431c954b4f52a5', // 高德导航API秘钥
     requestTimeout: 120 * 1000, // 网络请求最长时间120s
+    defaultGrayAvatar: 'https://mmbiz.qpic.cn/mmbiz/icTdbqWNOwNRna42FI242Lcia07jQodd2FJGIYQfG0LAJGFxM4FbnQP6yfMxBgJ0F3YRqJCJ1aPAK2dQagdusBZg/0',
     openid: '',
     session_key: '',
     userInfo: {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "shellbox",
-    "version": "3.3.5",
-    "description": "图床、图片上传改用七牛云CDN接口",
+    "version": "3.3.6",
+    "description": "取消使用七牛云，太贵了用不起&修复成绩单分享绘图",
     "author": "Airmole"
   }

--- a/pages/books/bind.wxml
+++ b/pages/books/bind.wxml
@@ -5,10 +5,10 @@
   </view>
   <block wx:else>
     <view>
-      <image class="title" src="https://cdn.airmole.cn/static/opac_bind_title.png"></image>
+      <image class="title" src="https://upload-images.jianshu.io/upload_images/4697920-e17d3ca1a6cdbadc.png"></image>
       <view class="content">
         <view class="hd" style="transform:rotateZ({{angle}}deg);">
-          <image class="logo" src="https://cdn.airmole.cn/static/book_icon.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240"></image>
+          <image class="logo" src="https://upload-images.jianshu.io/upload_images/4697920-07c3655a91520a4d.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240"></image>
           <image class="wave" src="/images/wave.png" mode="aspectFill"></image>
           <image class="wave wave-bg" src="/images/wave.png" mode="aspectFill"></image>
         </view>

--- a/pages/course/search.wxss
+++ b/pages/course/search.wxss
@@ -14,7 +14,7 @@
   height: 100px;
   opacity: 0.9;
   margin: 100rpx 0 30rpx;
-  background-image: url('https://cdn.airmole.cn/static/teachers_icon.png');
+  background-image: url('https://upload-images.jianshu.io/upload_images/4697920-84d9dc09f1d008ad.png');
 }
 
 .home .search-input {
@@ -374,13 +374,13 @@ button::after {
 }
 
 .ul-li-kb {
-  background: url('https://cdn.airmole.cn/static/table_icon.png') no-repeat;
+  background: url('https://upload-images.jianshu.io/upload_images/4697920-d983b3e897acc619.png') no-repeat;
   background-size: 30rpx 30rpx;
   background-position: 0 50%;
 }
 
 .ul-li-ks {
-  background: url('https://cdn.airmole.cn/static/pen_icon.png') no-repeat;
+  background: url('https://upload-images.jianshu.io/upload_images/4697920-289fecabc0b70761.png') no-repeat;
   background-size: 30rpx 30rpx;
   background-position: 0 50%;
 }

--- a/pages/elesys/bind.js
+++ b/pages/elesys/bind.js
@@ -11,7 +11,7 @@ Page({
     building_focus: false,
     room_focus: false,
     room: '',
-    bgimg: 'https://cdn.airmole.cn/static/elefare_bind_title.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+    bgimg: 'https://upload-images.jianshu.io/upload_images/4697920-32f0ab8c6c36493e.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
     angle: 0
   },
   onLoad: function (){

--- a/pages/index/feature.js
+++ b/pages/index/feature.js
@@ -8,8 +8,8 @@ Page({
     userInfo: {},
     isTeacher: false,
     clickAvatarCount: 1,
-    backgroundImage: 'https://cdn.airmole.cn/static/green_girl_background.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-    defaultAvatar: 'https://cdn.airmole.cn/static/default_gray_avatar.png',
+    backgroundImage: 'https://upload-images.jianshu.io/upload_images/4697920-48dab9eddafb6ce3.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+    defaultAvatar: app.globalData.defaultGrayAvatar,
     canShake: false,
     iconList: [
       {

--- a/pages/index/feature.wxml
+++ b/pages/index/feature.wxml
@@ -14,7 +14,7 @@
       </view>
       <view>您尚未登录</view>
     </view>
-    <image src="https://cdn.airmole.cn/static/water_wave.gif" mode="scaleToFill" class="gif-wave"></image>
+    <image src="https://upload-images.jianshu.io/upload_images/4697920-bf033361b1498e88.gif" mode="scaleToFill" class="gif-wave"></image>
   </view>
 
   <!-- 功能菜单 -->

--- a/pages/index/login.wxml
+++ b/pages/index/login.wxml
@@ -1,7 +1,7 @@
 <!--login.wxml-->
 <view class="container">
   <view class="remind-box" wx:if="{{remind}}">
-    <image class="remind-img" src="https://cdn.airmole.cn/static/bluecat_loading.gif?imageMogr2/auto-orient/strip"></image>
+    <image class="remind-img" src="https://upload-images.jianshu.io/upload_images/4697920-3401f7949a9e8b5c.gif?imageMogr2/auto-orient/strip"></image>
     <view class="text-white text-xl">正在登录，请耐心等候...</view>
     <view class="cu-progress bg-white round margin-top">
       <view class="bg-green" style="width:{{remind?(percent+'%'):''}};">{{percent}}%</view>

--- a/pages/index/setting.js
+++ b/pages/index/setting.js
@@ -1,9 +1,8 @@
 // pages/index/setting.js
 const app = getApp()
-const defaultAvatar = 'https://cdn.airmole.cn/static/default_gray_avatar.png'
 Page({
   data: {
-    avatarUrl: 'https://cdn.airmole.cn/static/default_gray_avatar.png',
+    avatarUrl: app.globalData.defaultGrayAvatar,
     nickname: ''
   },
   onLoad () {
@@ -25,7 +24,7 @@ Page({
       timeout: app.globalData.requestTimeout,
       success: function(res){
         if (res.statusCode == 200 && res.data.code == 200) {
-          const avatarUrl = res.data.data.avatar ? res.data.data.avatar : defaultAvatar
+          const avatarUrl = res.data.data.avatar ? res.data.data.avatar : app.globalData.defaultGrayAvatar
           const nickName = res.data.data.nickname ? res.data.data.nickname : uid
           _this.setData({ avatarUrl: avatarUrl, nickname: nickName })
           let userInfo = { avatarUrl: avatarUrl, nickName: nickName }

--- a/pages/netsys/bind.js
+++ b/pages/netsys/bind.js
@@ -9,7 +9,7 @@ Page({
     passwd_focus: false,
     netid: '',
     passwd: '',
-    bgimg: 'https://cdn.airmole.cn/static/netsys_bind_title.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+    bgimg: 'https://upload-images.jianshu.io/upload_images/4697920-61be38713bbefa8c.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
     angle: 0
   },
   onLoad: function (){

--- a/pages/school/aboutus.js
+++ b/pages/school/aboutus.js
@@ -10,23 +10,23 @@ Page({
     version: '',
     QGroupModal: false,
     showFreedomFunc: false,
-    weappCodeImage: 'https://cdn.airmole.cn/static/shellbox_miniprogram_codes.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+    weappCodeImage: 'https://upload-images.jianshu.io/upload_images/4697920-92c8f24e739051d3.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
     coder: [{
-      avatar: 'https://cdn.airmole.cn/static/airmole_avatar.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
+      avatar: 'https://upload-images.jianshu.io/upload_images/4697920-4bbd851e6b007d72.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
       nickName: 'Airmole',
       weibo: 'pages/profile/profile?objectUid=2423156830&nickname=Airmole'
     }, {
-      avatar: 'https://cdn.airmole.cn/static/henbf_avatar.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
+      avatar: 'https://upload-images.jianshu.io/upload_images/4697920-54c15375dfd9568e.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
       nickName: '很奔放',
       weibo: ''
     }, {
-      avatar: 'https://cdn.airmole.cn/static/fish_avatar.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
+      avatar: 'https://upload-images.jianshu.io/upload_images/4697920-5b0f0ef862d2e5e8.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
       nickName: '秃头程序媛',
       weibo: ''
     }],
     otherApps: [{
       appid: 'wx183616af30e5723d',
-      icon: 'https://cdn.airmole.cn/static/tjustb_schoolbus_icon.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
+      icon: 'https://upload-images.jianshu.io/upload_images/4697920-9f02095775140703.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128',
       name: '贝壳班车订票'
     }]
   },

--- a/pages/school/aboutus.wxml
+++ b/pages/school/aboutus.wxml
@@ -6,7 +6,7 @@
   <view class="header">
     <view class="black-cover">
     </view>
-    <image class="logo" src="https://cdn.airmole.cn/static/school_about_background.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240">
+    <image class="logo" src="https://upload-images.jianshu.io/upload_images/4697920-377a329782f5ea1f.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240">
     </image>
     <image class="title" src="/images/title.png">
     </image>
@@ -92,7 +92,7 @@
     <view class="cu-modal {{QGroupModal?'show':''}}">
       <view class="cu-dialog">
         <view class="bg-img"
-          style="background-image: url('https://cdn.airmole.cn/static/shellbox_qqgroup_qrcode.png');height:550px;">
+          style="background-image: url('https://upload-images.jianshu.io/upload_images/4697920-d843326d24a640da.png');height:550px;">
           <view class="cu-bar justify-end text-white">
             <view class="action" bindtap="hideModal">
               <text class="cuIcon-close "></text>

--- a/pages/school/board/detail.wxml
+++ b/pages/school/board/detail.wxml
@@ -14,7 +14,7 @@
       <view class="cu-item shadow">
         <view class="cu-list menu-avatar">
           <view class="cu-item">
-            <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://cdn.airmole.cn/static/quanyi_avatar.png);"></view>
+            <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://upload-images.jianshu.io/upload_images/4697920-5a559d389ef75773.png);"></view>
             <view class="content flex-sub">
               <view>{{data.content.id}}</view>
               <view class="text-gray text-sm flex justify-between">{{data.content.created_at}}</view>
@@ -93,7 +93,7 @@
         <view class="cu-item shadow solid-bottom" wx:for="{{data.replay}}" wx:key="board">
           <view class="cu-list menu-avatar">
             <view class="cu-item">
-              <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://cdn.airmole.cn/static/quanyi_logo.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128);"></view>
+              <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://upload-images.jianshu.io/upload_images/4697920-c9b94a8b22d5ee7e.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128);"></view>
               <view class="content flex-sub">
                 <view>权益中心工作人员 - {{item.nickname}}</view>
                 <view class="text-gray text-sm flex justify-between">{{item.created_at}}</view>

--- a/pages/school/board/faq.js
+++ b/pages/school/board/faq.js
@@ -9,7 +9,7 @@ Page({
     isLoading: true,
     isAdminer: false,
     uid: 0,
-    qrcode: 'https://cdn.airmole.cn/static/quanyi_qrcode.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/512',
+    qrcode: 'https://upload-images.jianshu.io/upload_images/4697920-03629fe77465b1b5.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/512',
     datalist: [],
     tags: ['其他', '食堂', '宿舍', '教学楼', '老师']
   },

--- a/pages/school/board/faq.wxml
+++ b/pages/school/board/faq.wxml
@@ -14,7 +14,7 @@
         <view class="cu-item shadow">
           <view class="cu-list menu-avatar">
             <view class="cu-item">
-              <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://cdn.airmole.cn/static/quanyi_avatar.png);"></view>
+              <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://upload-images.jianshu.io/upload_images/4697920-5a559d389ef75773.png);"></view>
               <view class="content flex-sub">
                 <view>{{item.id}}</view>
                 <view class="text-gray text-sm flex justify-between">{{item.created_at}}</view>

--- a/pages/school/board/index.js
+++ b/pages/school/board/index.js
@@ -10,7 +10,7 @@ Page({
     isLoading: true,
     isAdminer: false,
     uid: 0,
-    qrcode: 'https://cdn.airmole.cn/static/quanyi_qrcode.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/512',
+    qrcode: 'https://upload-images.jianshu.io/upload_images/4697920-03629fe77465b1b5.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/512',
     datalist: [],
     hotDatalist: [],
     tags: ['其他', '食堂', '宿舍', '教学楼', '老师'],

--- a/pages/school/board/index.wxml
+++ b/pages/school/board/index.wxml
@@ -84,7 +84,7 @@
         <view class="cu-item shadow">
           <view class="cu-list menu-avatar">
             <view class="cu-item">
-              <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://cdn.airmole.cn/static/quanyi_avatar.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128);"></view>
+              <view class="cu-avatar round lg bg-cyan" style="background-image:url(https://upload-images.jianshu.io/upload_images/4697920-5a559d389ef75773.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/128);"></view>
               <view class="content flex-sub">
                 <view>{{item.id}}</view>
                 <view class="text-gray text-sm flex justify-between">{{item.created_at}}</view>

--- a/pages/school/calendar.js
+++ b/pages/school/calendar.js
@@ -5,7 +5,7 @@ Page({
    * 页面的初始数据
    */
   data: {
-    calendarImage: 'https://cdn.airmole.cn/image/calendar/2022-2023-1.jpeg',
+    calendarImage: 'https://upload-images.jianshu.io/upload_images/4697920-f91669d4f0f98ca1.jpeg',
     isLoading: true,
     screenHeight: '900',
     colorArr: ['red','orange','yellow','olive','green','cyan','blue','purple','mauve','pink','brown','grey','gray'],

--- a/pages/school/card/bind.js
+++ b/pages/school/card/bind.js
@@ -6,7 +6,7 @@ Page({
    * 页面的初始数据
    */
   data: {
-    webImage: 'https://cdn.airmole.cn/static/ehall_tips.png',
+    webImage: 'https://upload-images.jianshu.io/upload_images/4697920-b9667ae84f3059d7.png',
     uid: '',
     password: ''
   },

--- a/pages/school/cert.js
+++ b/pages/school/cert.js
@@ -80,19 +80,16 @@ Page({
           subtitle: '官网',
           url: 'http://kzp.mof.gov.cn/index.jsp'
         }, {
-          subtitle: '报名',
-          url: 'http://kjbm.mof.gov.cn/index-sf_cg.jsp'
-        }, {
           subtitle: '成绩查询',
           url: 'http://kzp.mof.gov.cn/cjcx/cjcx.jsp'
         }]
       },
       {
-        title: '普通话水平测试(天津)',
+        title: '普通话水平测试',
         hookId: 'cltt',
         content: [{
           subtitle: '报名',
-          url: 'http://tj.cltt.org/Web/SignUpOnLine/Default.aspx'
+          url: 'http://bm.cltt.org/'
         }]
       },
       {
@@ -104,26 +101,6 @@ Page({
         }, {
           subtitle: '报名',
           url: 'https://bm.ruankao.org.cn/sign/welcome'
-        }, {
-          subtitle: '准考证',
-          url: 'https://bm.ruankao.org.cn/shortCut/searchCard'
-        }, {
-          subtitle: '成绩查询',
-          url: 'https://query.ruankao.org.cn/score'
-        }]
-      },
-      {
-        title: '导游资格考试',
-        hookId: 'daoyou',
-        content: [{
-          subtitle: '官网',
-          url: 'https://c-dy.exam-sp.com/'
-        }, {
-          subtitle: '报名',
-          url: 'https://c-dy.exam-sp.com/#/default/examReg/chooseBatch'
-        }, {
-          subtitle: '准考证',
-          url: 'https://c-dy.exam-sp.com/#/default/print'
         }]
       },
       {
@@ -132,15 +109,6 @@ Page({
         content: [{
           subtitle: '官网',
           url: 'https://www.sac.net.cn/cyry/kspt/kstz/'
-        }, {
-          subtitle: '报名',
-          url: 'https://www.sac.net.cn/cyry/kspt/ksbm/'
-        }, {
-          subtitle: '准考证',
-          url: 'https://www.sac.net.cn/cyry/kspt/zkzdy/'
-        }, {
-          subtitle: '成绩',
-          url: 'https://www.sac.net.cn/cyry/kspt/kscjcx/'
         }]
       },
       {
@@ -148,13 +116,16 @@ Page({
         hookId: 'jijin',
         content: [{
           subtitle: '报名',
-          url: 'http://baoming.amac.org.cn:10080/JJKSreg/page.htm'
+          url: 'https://www.amac.org.cn/'
         }]
       },
       {
         title: '银行从业资格考试',
         hookId: 'bank',
         content: [{
+          subtitle: '官网',
+          url: 'https://www.china-cba.net/Index/lists/catid/31.html'
+        },{
           subtitle: '报名',
           url: 'http://cj.ccbp.org.cn/apply/'
         }]
@@ -163,9 +134,6 @@ Page({
         title: '期货从业资格考试',
         hookId: 'qihuo',
         content: [{
-          subtitle: '官网',
-          url: 'http://cfa.ata.net.cn/Portal/'
-        }, {
           subtitle: '报名',
           url: 'http://cfa.ata.net.cn/site/#/default/login'
         }]
@@ -175,13 +143,10 @@ Page({
         hookId: 'cpa',
         content: [{
           subtitle: '官网',
-          url: 'http://cpaexam.cicpa.org.cn/default.shtml'
+          url: 'https://www.cicpa.org.cn/'
         }, {
           subtitle: '报名',
-          url: 'http://cpaexam.cicpa.org.cn/login'
-        }, {
-          subtitle: '成绩查询',
-          url: 'http://cpaexam.cicpa.org.cn/scorequeryhis'
+          url: 'https://www.cicpa.org.cn/ztzl1/exam/'
         }]
       },
       {
@@ -189,7 +154,7 @@ Page({
         hookId: 'laywer',
         content: [{
           subtitle: '官网',
-          url: 'http://sfks.bjsf.gov.cn/jeplatform/websitebj/index.jsp'
+          url: 'http://www.moj.gov.cn/jgsz/jgszzsdw/zsdwgjsfkszx/'
         }]
       },
       {

--- a/pages/school/cert.wxml
+++ b/pages/school/cert.wxml
@@ -42,8 +42,6 @@
           wx:key="contentKey">
           <view class="desc-title">{{subItem.subtitle}}：</view>
           <view class="desc-content" data-url="{{subItem.url}}" bindtap="copyUrl"> - {{subItem.url}}</view>
-          <view wx:if="{{subItem.url=='http://cet.neea.edu.cn/cet/'}}" class="desc-content" data-url="{{subItem.url}}"
-            bindtap="goToOtherWeapp"> - 直接前往查询</view>
         </view>
       </view>
     </block>

--- a/pages/school/finance/bind.wxml
+++ b/pages/school/finance/bind.wxml
@@ -5,10 +5,10 @@
   </view>
   <block wx:else>
     <view>
-      <image class="title" src="https://cdn.airmole.cn/static/finance_bind_title.png"></image>
+      <image class="title" src="https://upload-images.jianshu.io/upload_images/4697920-3fab34adc9ce45b7.png"></image>
       <view class="content">
         <view class="hd" style="transform:rotateZ({{angle}}deg);">
-          <image class="logo" src="https://cdn.airmole.cn/static/finance_icon.png"></image>
+          <image class="logo" src="https://upload-images.jianshu.io/upload_images/4697920-2a921a218f8bcd53.png"></image>
           <image class="wave" src="/images/wave.png" mode="aspectFill"></image>
           <image class="wave wave-bg" src="/images/wave.png" mode="aspectFill"></image>
         </view>

--- a/pages/school/lost/detail.js
+++ b/pages/school/lost/detail.js
@@ -6,7 +6,7 @@ Page({
    */
   data: {
     env: 'develop',
-    defaultAvatar: 'https://cdn.airmole.cn/static/default_gray_avatar.png',
+    defaultAvatar: app.globalData.defaultGrayAvatar,
     isLoading: true,
     isPublisher: false,
     isRecevicer: false,

--- a/pages/school/lost/index.js
+++ b/pages/school/lost/index.js
@@ -9,7 +9,7 @@ Page({
     title: '失物招领',
     isLoading: '加载中',
     screenHeight: '900',
-    defaultAvatar: 'https://cdn.airmole.cn/static/default_gray_avatar.png',
+    defaultAvatar: app.globalData.defaultGrayAvatar,
     keyword: '',
     type: 1,
     uid: '',

--- a/pages/school/run/index.js
+++ b/pages/school/run/index.js
@@ -7,14 +7,14 @@ Page({
   data: {
     env: 'develop',
     type: '0',
-    defaultAvatar: 'https://cdn.airmole.cn/static/default_gray_avatar.png',
-    avatar: 'https://cdn.airmole.cn/static/default_gray_avatar.png',
+    defaultAvatar: app.globalData.defaultGrayAvatar,
+    avatar: app.globalData.defaultGrayAvatar,
     nickname: '',
-    fillImage: 'https://cdn.airmole.cn/static/werun_fill_image.jpeg',
+    fillImage: 'https://upload-images.jianshu.io/upload_images/4697920-646f99ca82fdc62b.jpeg',
     top3icon: [
-      'https://cdn.airmole.cn/static/werun_top1.png',
-      'https://cdn.airmole.cn/static/werun_top2.png',
-      'https://cdn.airmole.cn/static/werun_top3.png'
+      'https://upload-images.jianshu.io/upload_images/4697920-afd8b750ea3b5c32.png',
+      'https://upload-images.jianshu.io/upload_images/4697920-0b0376bfe0c8af85.png',
+      'https://upload-images.jianshu.io/upload_images/4697920-2fbab52779447beb.png'
     ],
     types: [{
       name: '今日排行',

--- a/pages/school/run/index.wxml
+++ b/pages/school/run/index.wxml
@@ -4,7 +4,7 @@
     <view slot="content">步数排行 - 贝壳小盒子</view>
   </cu-custom>
 
-  <image class="image-width" src="https://cdn.airmole.cn/static/werun_rank_top.jpeg" mode="widthFix" widthFix></image>
+  <image class="image-width" src="https://upload-images.jianshu.io/upload_images/4697920-a166bb5d0420fef4.jpeg" mode="widthFix" widthFix></image>
 
   <view class="bg-img" style="background-image: url({{fillImage}});margin-top: -5px;">
     <view class="padding-top-xs padding-lr-xl text-black">
@@ -46,7 +46,7 @@
     </view>
   </view>
 
-  <image class="image-width bottom-image" src="https://cdn.airmole.cn/static/werun_rank_foot.jpeg" mode="widthFix" widthFix></image>
+  <image class="image-width bottom-image" src="https://upload-images.jianshu.io/upload_images/4697920-a75573126934d7d2.jpeg" mode="widthFix" widthFix></image>
 
 
   <view style="height: 180rpx;" class="cu-bar bg-gradual-pink tabbar radius border shop foot" wx:if="{{personalRank[0]}}">

--- a/pages/school/web.js
+++ b/pages/school/web.js
@@ -8,81 +8,81 @@ Page({
     wan: [
       [{
         title: '学院官网',
-        background: 'https://cdn.airmole.cn/website/school_homepage.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-cb8ee15220e00023.png',
         url: ['http://tj.ustb.edu.cn']
       },
       {
         title: '教务系统',
-        background: 'https://cdn.airmole.cn/website/school_edusys.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-31abfba9d10d4f20.png',
         url: ['http://61.181.145.1:89/jsxsd', 'http://117.131.241.67:89/jsxsd']
       }],
       [{
         title: '财务(学费查询)',
-        background: 'https://cdn.airmole.cn/website/school_finansys.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-487ee29d884cc028.png',
         url: ['http://221.238.213.131:8809']
       },
       {
         title: '网上大厅',
-        background: 'https://cdn.airmole.cn/website/school_ehall.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-dba3529e96f74efb.png',
         url: ['http://ehall.bkty.top']
       }]
     ],
     lan: [
       [{
         title: '学院官网',
-        background: 'https://cdn.airmole.cn/website/school_homepage.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-cb8ee15220e00023.png',
         url: ['http://10.1.254.70']
       },
       {
         title: '网费查询',
-        background: 'https://cdn.airmole.cn/website/school_netfare.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-45814d1b2fa8da6c.png',
         url: ['http://10.1.254.112/Self']
       }],
       [{
         title: '入党学习',
-        background: 'https://cdn.airmole.cn/website/school_joinparty.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-cb05959c5e47abfc.png',
         url: ['http://10.1.254.27']
       }, {
         title: '校园网计费登录',
-        background: 'https://cdn.airmole.cn/website/school_schoolnet.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-61231fefddf211ac.png',
         url: ['http://172.16.1.3']
       }],
       [{
         title: '教务系统',
-        background: 'https://cdn.airmole.cn/website/school_edusys.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-31abfba9d10d4f20.png',
         url: ['http://10.1.254.87/jsxsd']
       },
       {
         title: '图书检索',
-        background: 'https://cdn.airmole.cn/website/school_opac.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-0b70730a135ad56d.png',
         url: ['http://10.1.254.101:82']
       }],
       [{
         title: '图书馆数字资源',
-        background: 'https://cdn.airmole.cn/website/school_ebook.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-627c8c3607690f6d.png',
         url: ['http://10.1.254.107']
       },
       {
         title: '图书馆',
-        background: 'https://cdn.airmole.cn/website/school_library.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-47370bd93784207a.png',
         url: ['http://10.1.254.101']
       }],
       [{
         title: '财务(学费查询)',
-        background: 'https://cdn.airmole.cn/website/school_finansys.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-487ee29d884cc028.png',
         url: ['http://10.2.254.80:8809']
       },{
         title: '财管系统',
-        background: 'https://cdn.airmole.cn/website/school_finansys.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-487ee29d884cc028.png',
         url: ['http://10.2.254.80']
       }],
       [{
         title: '资产与实验室管理',
-        background: 'https://cdn.airmole.cn/website/school_laboratory.png',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-c86e5b66a7e513ec.png',
         url: ['http://10.1.254.170']
       }, {
         title: '心理咨询中心',
-        background: 'https://cdn.airmole.cn/static/green_girl_background.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/300',
+        background: 'https://upload-images.jianshu.io/upload_images/4697920-48dab9eddafb6ce3.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/300',
         url: ['http://10.1.254.51']
       }]
     ]

--- a/pages/school/xiaoai.js
+++ b/pages/school/xiaoai.js
@@ -6,18 +6,18 @@ Page({
    */
   data: {
     isLoading:true,
-    cover: 'https://cdn.airmole.cn/static/xiaoai/cover.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+    cover: 'https://upload-images.jianshu.io/upload_images/4697920-fc4ca94341465a0c.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
     guideImages:[
-      'https://cdn.airmole.cn/static/xiaoai/step1.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step2.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step3.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step4.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step5.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step6.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step7.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step8.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step9.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
-      'https://cdn.airmole.cn/static/xiaoai/step10.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240'
+      'https://upload-images.jianshu.io/upload_images/4697920-160801a94ef0039a.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-67c3f6650998eee6.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-19c2e81ae14d4e15.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-3e034cf229e93284.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-50e80fc9566bab30.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-43ddace2b43ddf58.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-f9d98473ae6ead5e.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-f1418ec9f834aef0.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-3705a1e3879ce130.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240',
+      'https://upload-images.jianshu.io/upload_images/4697920-43945b1dc3e74a4e.png?imageMogr2/auto-orient/strip%7CimageView2/2/w/1240'
     ]
   },
 

--- a/pages/score/score.js
+++ b/pages/score/score.js
@@ -168,7 +168,7 @@ Page({
       mask: true
     })
 
-    let userNickName = app.globalData.userInfo.nickName;
+    let userNickName = app.globalData.edusysUserInfo.nickname;
     if (userNickName == '') userNickName = app.globalData.edusysUserInfo.uid
     let nickName = {
       type: 'text',
@@ -210,14 +210,14 @@ Page({
     var whitePaperHeight = (midNum * 20) + 35;
     var pushArr = [{
       type: 'image',
-      url: 'https://upload-images.jianshu.io/upload_images/4697920-b926d6f7b128a808.png',
+      url: 'https://store2018.muapp.cn/images/4697920-b926d6f7b128a808.png',
       top: 0,
       left: 0,
       width: 600,
       height: 390
     }, {
       type: 'image',
-      url: 'https://upload-images.jianshu.io/upload_images/4697920-d0909159d03389c5.png',
+      url: 'https://store2018.muapp.cn/images/4697920-d0909159d03389c5.png',
       top: 390 + whitePaperHeight,
       left: 0,
       width: 600,
@@ -346,12 +346,12 @@ Page({
     pushArr = pushArr.concat(makeupFullPicArr);
 
     var topX = 400;
-    var leftY = 20;
+    var leftY = 30;
     for (let i = 0; i < midNum; i++) {
       topX = topX + 20;
       let tempNo = {
         type: 'text',
-        content: newArr[i].SerialNo ? newArr[i].SerialNo : '',
+        content: newArr[i].SerialNo + '',
         fontSize: 14,
         color: '#000',
         textAlign: 'left',

--- a/pages/traffic/navi.js
+++ b/pages/traffic/navi.js
@@ -14,7 +14,7 @@ Page({
     activePlaceID: -1,
     schoolAddressText: '天津市宝坻区京津新城珠江北环东路1号',
     postcode: '301830',
-    staticMapImage: 'https://cdn.airmole.cn/image/tjustb_map.jpeg',
+    staticMapImage: 'https://upload-images.jianshu.io/upload_images/4697920-d484de3e9d949dab.jpeg',
     markers: [{
       id: 0,
       latitude: 39.544736,

--- a/utils/canvasdrawer/canvasdrawer.js
+++ b/utils/canvasdrawer/canvasdrawer.js
@@ -38,7 +38,7 @@ Component({
   cache: {},
   ready () {
     wx.removeStorageSync('canvasdrawer_pic_cache')
-    this.cache = wx.getStorageSync('canvasdrawer_pic_cache')
+    this.cache = wx.getStorageSync('canvasdrawer_pic_cache') || {}
     this.ctx = wx.createCanvasContext('canvasdrawer', this)
   },
   methods: {


### PR DESCRIPTION
1. 取消使用自由的七牛云CDN太贵了，用不起
2. 更新考证助手数据
3. 成绩分享海报绘制修复
4. app.js使用统一灰色头像